### PR TITLE
#154724378 Integrate circleCI with Readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reaction Commerce
-[![bitHound Overall Score](https://www.bithound.io/github/andela/kenya-rc/badges/score.svg)](https://www.bithound.io/github/andela/kenya-rc) [![bitHound Dev Dependencies](https://www.bithound.io/github/andela/kenya-rc/badges/devDependencies.svg)](https://www.bithound.io/github/andela/kenya-rc/develop/dependencies/npm) [![bitHound Code](https://www.bithound.io/github/andela/kenya-rc/badges/code.svg)](https://www.bithound.io/github/andela/kenya-rc)
-[![Circle CI](https://circleci.com/gh/reactioncommerce/reaction.svg?style=svg)](https://circleci.com/gh/reactioncommerce/reaction) [![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/reactioncommerce/reaction?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![bitHound Overall Score](https://www.bithound.io/github/andela/kenya-rc/badges/score.svg)](https://www.bithound.io/github/andela/kenya-rc) [![bitHound Dev Dependencies](https://www.bithound.io/github/andela/kenya-rc/badges/devDependencies.svg)](https://www.bithound.io/github/andela/kenya-rc/develop/dependencies/npm) [![bitHound Code](https://www.bithound.io/github/andela/kenya-rc/badges/code.svg)](https://www.bithound.io/github/andela/kenya-rc) [![CircleCI](https://circleci.com/gh/andela/kenya-rc.svg?style=svg)](https://circleci.com/gh/andela/kenya-rc)
+[![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/reactioncommerce/reaction?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [Reaction](http://reactioncommerce.com) is an event-driven, real-time reactive commerce platform built with JavaScript (ES6). It plays nicely with npm, Docker, and React.
 


### PR DESCRIPTION
#### What does this PR do?
Integrate circleCI with badge attached to readme

#### Description of Task to be completed?
Obtain circleCI badges from circleci.com

#### How should this be manually tested?
* Visit the github repository
* Navigate to the README.md file, the badges are visible

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#154724378 Integrate circleCI with Readme badge

#### Screenshots (if appropriate)
<img width="1432" alt="screen shot 2018-01-30 at 5 18 14 pm" src="https://user-images.githubusercontent.com/24475008/35577341-99eb0400-05e1-11e8-995d-8bb5bd896a4d.png">


#### Questions:
N/A
