### PR TITLE
#154715727 Make the API endpoints RESTful

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -94,3 +94,4 @@ johanbrook:publication-collector
 # meteorhacks:sikka                         # additional ddp, login security
 
 # Custom Packages
+nimble:restivus

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -120,6 +120,7 @@ mongo-id@1.0.6
 mongo-livedata@1.0.12
 mrt:later@1.6.1
 natestrauser:select2@4.0.3
+nimble:restivus@0.8.12
 npm-bcrypt@0.9.3
 npm-mongo@2.2.33
 oauth@1.1.13
@@ -148,6 +149,7 @@ service-configuration@1.0.11
 session@1.1.7
 sha@1.0.9
 shell-server@0.2.4
+simple:json-routes@2.1.0
 spacebars@1.0.15
 spacebars-compiler@1.1.3
 srp@1.0.10

--- a/server/startup/index.js
+++ b/server/startup/index.js
@@ -5,6 +5,7 @@ import Registry from "./registry";
 import Init from "./init";
 import Prerender from "./prerender";
 import { initTemplates } from "/server/api/core/templates";
+import restApi from "./restApiEndpoints";
 
 
 export default function () {
@@ -15,4 +16,5 @@ export default function () {
   Registry();
   Init();
   Prerender();
+  restApi();
 }

--- a/server/startup/restApiEndpoints.js
+++ b/server/startup/restApiEndpoints.js
@@ -1,0 +1,183 @@
+import collections from "../../lib/collections";
+import Reaction from "../../server/api/core";
+
+/**
+ * @param {Object} user
+ * @param {String} role
+ * @returns {boolean}
+ */
+const hasPermission = (user, role) => {
+  return user.roles[Reaction.getShopId()].includes(role);
+};
+
+// eslint-disable-next-line no-undef
+const Api = new Restivus({
+  useDefaultAuth: true,
+  prettyJson: true,
+  version: "v1",
+  defaultHeaders: {
+    "Content-Type": "application/json"
+  }
+});
+
+/**
+ * @param {String} collectionName - Name of collection
+ * @param {Object} collection - collection Schema
+ * @param {Object} restApi - object
+ * @returns none
+ */
+const createRestApiFor = (collectionName, collection, restApi = Api) => {
+  restApi.addCollection(collection, {
+    path: collectionName,
+    routeOptions: { authRequired: true },
+    endpoints: {
+      getAll: {
+        authRequired: true,
+        action() {
+          if (hasPermission(this.user, "admin") || hasPermission(this.user, "guest") || hasPermission(this.user, "owner")) {
+            const all = collection.find().fetch();
+            if (!all) {
+              return {
+                status: "failed",
+                statusCode: 404,
+                message: `No ${collectionName} found!`
+              };
+            }
+            return {
+              status: "success",
+              statusCode: 200,
+              data: {
+                all
+              }
+            };
+          }
+          return {
+            statusCode: 403, status: "failed",
+            message: "You do not have permission to get a record"
+          };
+        }
+      },
+      post: {
+        authRequired: true,
+        action() {
+          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
+            let error = false;
+            let id;
+            if (this.bodyParams) {
+              collection.insert(this.bodyParams, (err, _id) => {
+                if (err) {
+                  error = true;
+                }
+                id = _id;
+              });
+              return error ? {
+                status: "Failed",
+                statusCode: 500,
+                message: `unable to add ${collectionName}`
+              } : {
+                status: "success",
+                statusCode: 201,
+                data: {
+                  id
+                }
+              };
+            }
+          }
+          return {
+            statusCode: 403, status: "failed",
+            message: "You do not have permission to add a record"
+          };
+        }
+      },
+      get: {
+        authRequired: true,
+        action() {
+          if (hasPermission(this.user, "admin") || hasPermission(this.user, "guest") || hasPermission(this.user, "owner")) {
+            const foundItems = collection.findOne(this.urlParams.id);
+            if (foundItems !== undefined) {
+              return {
+                status: "success",
+                statusCode: 200,
+                data: foundItems
+              };
+            }
+            return {
+              status: "failed",
+              statusCode: 404,
+              message: `Could not find ${collectionName} with id ${this.urlParams.id}`
+            };
+          }
+          return {
+            statusCode: 403, status: "failed",
+            message: "You do not have permission to get a record"
+          };
+        }
+      },
+
+      put: {
+        authRequired: true,
+        action() {
+          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
+            const updatedItem = collection.update(this.urlParams.id, this.bodyParams, { upsert: true });
+            if (!updatedItem) {
+              return {
+                status: "failed",
+                statusCode: 500,
+                message: "Request was not processed"
+              };
+            }
+            return {
+              status: "success",
+              statusCode: 200,
+              data: updatedItem
+            };
+          }
+          return {
+            statusCode: 403, status: "failed",
+            message: "You do not have permission to update a record"
+          };
+        }
+
+      },
+      delete: {
+        authRequired: true,
+        action() {
+          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
+            if (collection.remove(this.urlParams.id)) {
+              return {
+                status: "success",
+                data: {
+                  message: `${collectionName} deleted successfuly`
+                }
+              };
+            }
+            return {
+              status: "failed",
+              statusCode: 404,
+              message: `${collectionName} not found`
+            };
+          }
+          return {
+            status: "failed",
+            statusCode: 403,
+            message: "You do not have permission to delete a record"
+          };
+        }
+      }
+    }
+  });
+}
+
+
+export default () => {
+  createRestApiFor("accounts", collections.Accounts);
+  createRestApiFor("cart", collections.Cart);
+  createRestApiFor("emails", collections.Emails);
+  createRestApiFor("inventory", collections.Inventory);
+  createRestApiFor("orders", collections.Orders);
+  createRestApiFor("products", collections.Products);
+  createRestApiFor("shops", collections.Shops);
+  createRestApiFor("tags", collections.Tags);
+  createRestApiFor("groups", collections.Groups);
+  createRestApiFor("shipping", collections.Shipping);
+};

--- a/server/startup/restApiEndpoints.js
+++ b/server/startup/restApiEndpoints.js
@@ -6,9 +6,6 @@ import Reaction from "../../server/api/core";
  * @param {String} role
  * @returns {boolean}
  */
-const hasPermission = (user, role) => {
-  return user.roles[Reaction.getShopId()].includes(role);
-};
 
 // eslint-disable-next-line no-undef
 const Api = new Restivus({
@@ -29,145 +26,9 @@ const Api = new Restivus({
 const createRestApiFor = (collectionName, collection, restApi = Api) => {
   restApi.addCollection(collection, {
     path: collectionName,
-    routeOptions: { authRequired: true },
-    endpoints: {
-      getAll: {
-        authRequired: true,
-        action() {
-          if (hasPermission(this.user, "admin") || hasPermission(this.user, "guest") || hasPermission(this.user, "owner")) {
-            const all = collection.find().fetch();
-            if (!all) {
-              return {
-                status: "failed",
-                statusCode: 404,
-                message: `No ${collectionName} found!`
-              };
-            }
-            return {
-              status: "success",
-              statusCode: 200,
-              data: {
-                all
-              }
-            };
-          }
-          return {
-            statusCode: 403, status: "failed",
-            message: "You do not have permission to get a record"
-          };
-        }
-      },
-      post: {
-        authRequired: true,
-        action() {
-          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
-            let error = false;
-            let id;
-            if (this.bodyParams) {
-              collection.insert(this.bodyParams, (err, _id) => {
-                if (err) {
-                  error = true;
-                }
-                id = _id;
-              });
-              return error ? {
-                status: "Failed",
-                statusCode: 500,
-                message: `unable to add ${collectionName}`
-              } : {
-                status: "success",
-                statusCode: 201,
-                data: {
-                  id
-                }
-              };
-            }
-          }
-          return {
-            statusCode: 403, status: "failed",
-            message: "You do not have permission to add a record"
-          };
-        }
-      },
-      get: {
-        authRequired: true,
-        action() {
-          if (hasPermission(this.user, "admin") || hasPermission(this.user, "guest") || hasPermission(this.user, "owner")) {
-            const foundItems = collection.findOne(this.urlParams.id);
-            if (foundItems !== undefined) {
-              return {
-                status: "success",
-                statusCode: 200,
-                data: foundItems
-              };
-            }
-            return {
-              status: "failed",
-              statusCode: 404,
-              message: `Could not find ${collectionName} with id ${this.urlParams.id}`
-            };
-          }
-          return {
-            statusCode: 403, status: "failed",
-            message: "You do not have permission to get a record"
-          };
-        }
-      },
-
-      put: {
-        authRequired: true,
-        action() {
-          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
-            const updatedItem = collection.update(this.urlParams.id, this.bodyParams, { upsert: true });
-            if (!updatedItem) {
-              return {
-                status: "failed",
-                statusCode: 500,
-                message: "Request was not processed"
-              };
-            }
-            return {
-              status: "success",
-              statusCode: 200,
-              data: updatedItem
-            };
-          }
-          return {
-            statusCode: 403, status: "failed",
-            message: "You do not have permission to update a record"
-          };
-        }
-
-      },
-      delete: {
-        authRequired: true,
-        action() {
-          if (hasPermission(this.user, "admin") || hasPermission(this.user, "owner")) {
-            if (collection.remove(this.urlParams.id)) {
-              return {
-                status: "success",
-                data: {
-                  message: `${collectionName} deleted successfuly`
-                }
-              };
-            }
-            return {
-              status: "failed",
-              statusCode: 404,
-              message: `${collectionName} not found`
-            };
-          }
-          return {
-            status: "failed",
-            statusCode: 403,
-            message: "You do not have permission to delete a record"
-          };
-        }
-      }
-    }
+    routeOptions: { authRequired: true }
   });
-}
-
+};
 
 export default () => {
   createRestApiFor("accounts", collections.Accounts);

--- a/server/startup/restApiEndpoints.js
+++ b/server/startup/restApiEndpoints.js
@@ -1,12 +1,6 @@
 import collections from "../../lib/collections";
 import Reaction from "../../server/api/core";
 
-/**
- * @param {Object} user
- * @param {String} role
- * @returns {boolean}
- */
-
 // eslint-disable-next-line no-undef
 const Api = new Restivus({
   useDefaultAuth: true,


### PR DESCRIPTION
#### What does this PR do?
Extend Meteor DDP methods and provide restful API.

#### How should this be manually tested?
Run ```reaction```

Go to postman and try the following route:

```
Shops : api/v1/shops
Products: api/v1/products
Orders: api/v1/orders
Cart: api/v1/cart
Inventory: api/v1/inventory
Accounts: api/v1/accounts
Groups: api/v1/groups
Tags: api/v1/tags
Shipping: api/v1/shipping
```

Any background context you want to provide?
N/A

What are the relevant pivotal tracker stories?
#154715727 Make the API endpoints RESTful

#### Screenshots (if appropriate)
<img width="1108" alt="screen shot 2018-02-13 at 8 34 46 pm" src="https://user-images.githubusercontent.com/24475008/36169764-724ba1ee-10fd-11e8-8b6d-0c638a6ed9ab.png">
<img width="1136" alt="screen shot 2018-02-13 at 8 35 01 pm" src="https://user-images.githubusercontent.com/24475008/36169777-7a734da4-10fd-11e8-8d9f-90ccb2a64c07.png">
<img width="1132" alt="screen shot 2018-02-13 at 8 35 20 pm" src="https://user-images.githubusercontent.com/24475008/36169818-a6e7de36-10fd-11e8-9ad6-10ec16290822.png">

#### Questions:
N/A