### PR TITLE
#154715730 display real-time results as shopper is typing

### DIFF
--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -9,15 +9,20 @@ import { ProductSearch, OrderSearch, AccountSearch } from "/lib/collections";
 const supportedCollections = ["products", "orders", "accounts"];
 
 function getProductFindTerm(searchTerm, searchTags, userId) {
-  const shopId = Reaction.getShopId();
+  const shopIds = Reaction.getShopId();
   const findTerm = {
-    shopId: shopId,
-    $text: { $search: searchTerm }
+    $and: [
+      { shopId: shopIds },
+      { title: {
+        $regex: searchTerm,
+        $options: "i"
+      } }
+    ]
   };
   if (searchTags.length) {
     findTerm.hashtags = { $all: searchTags };
   }
-  if (!Roles.userIsInRole(userId, ["admin", "owner"], shopId)) {
+  if (!Roles.userIsInRole(userId, ["admin", "owner"], shopIds)) {
     findTerm.isVisible = true;
   }
   return findTerm;

--- a/imports/plugins/included/ui-search/lib/components/searchModal.js
+++ b/imports/plugins/included/ui-search/lib/components/searchModal.js
@@ -98,6 +98,9 @@ class SearchModal extends Component {
           {this.renderSearchInput()}
           {this.renderSearchTypeToggle()}
           {this.props.tags.length > 0 && this.renderProductSearchTags()}
+          {this.props.value.length > 1 &&
+          this.props.products.length < 1 &&
+          <h3><strong>No Product(s) Found</strong></h3>}
         </div>
         <div className="rui search-modal-results-container">
           {this.props.products.length > 0 &&


### PR DESCRIPTION
#### What does this PR do?
display real-time results as shopper is typing.

#### Description of Task to be completed?
* modify search content to search the title schema
* make search content case insensitive

#### How should this be manually tested?
* cloning the repo,
* change directory in kenya-rc and run meteor npm install to install dependencies
* run ``` reaction ``` on the terminal
* start the server by visiting ``` localhost:3000 ```
* click on the search icon and start searching for real time result

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#154715730 display real-time results as shopper is typing

### Screenshots
<img width="1421" alt="screen shot 2018-02-21 at 11 26 00 am" src="https://user-images.githubusercontent.com/24475008/36475144-1701e354-16fa-11e8-920b-97e1bdf9bb64.png">
<img width="1428" alt="screen shot 2018-02-21 at 11 26 20 am" src="https://user-images.githubusercontent.com/24475008/36475161-2167baee-16fa-11e8-9f6e-f08608c85ceb.png">


#### Questions:
N/A